### PR TITLE
Updated and fixed storage clients, commit hooks, revised instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  # Run ruff linter and formatter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
+  # Make sure your uv.lock file is up to date.
+  # (Even if your pyproject.toml file was changed via pre-commit.)
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.5.24
+    hooks:
+      - id: uv-lock
+  # Run pyright
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.392
+    hooks:
+    - id: pyright
+  # Format Markdown
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.21  # Use the ref you want to point at
+    hooks:
+    - id: mdformat
+      # Optionally add plugins
+      additional_dependencies:
+      - mdformat-gfm
+      - mdformat-frontmatter
+      - mdformat-footnote
+      - mdformat-gfm-alerts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,35 @@ First off, thank you for considering contributing to the Chainlit Community repo
 
 ## Getting Started
 
+### Requirements
+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+
+### Setting up
+
+We use uv for package management.
+
+With uv installed, follow these steps to set up your development environment:
+
+1. Install pre-commit hooks: `uv run pre-commit install --install-hooks`
+   This will enable automatic formatting, syntax checking and fixups for your contributions.
+1. Done!
+
+### Adding packages
+
+1. Copy (`cp -r`) the package similar to what you want to create, e.g.:
+   `cp -r packages/data_layers/sqlalchemy packages/data_layers/bananadb`
+1. Rename references to previous data layer in filenames, `pyproject.toml` and `README.md`.
+1. Add the package to `members` in `[tool.uv.workspace]` in the root [`pyproject.toml`](pyproject.toml):
+   ```toml
+   [tool.uv.workspace]
+   members = [
+      ...
+       "packages/data_layers/bananadb",
+       ...
+   ]
+   ```
+
 ### Issues
 
 - Feel free to open issues to report bugs, suggest improvements, or propose new features.
@@ -24,42 +53,10 @@ First off, thank you for considering contributing to the Chainlit Community repo
 ### Pull Requests
 
 1. Fork the repository and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. Ensure your code passes all tests and linting.
-4. Update the documentation, if necessary.
-5. Issue the pull request!
-
-## Development Setup
-
-We use Poetry for package management. Follow these steps to set up your development environment:
-
-1. Install Poetry if you haven't already:
-   ```
-   pip install poetry
-   ```
-
-2. Clone your fork of the repository:
-   ```
-   git clone https://github.com/YOUR_USERNAME/chainlit-community.git
-   cd chainlit-community
-   ```
-
-3. Install the project dependencies:
-   ```
-   poetry install
-   ```
-
-4. Activate the virtual environment:
-   ```
-   poetry shell
-   ```
-
-5. Set up pre-commit hooks:
-   ```
-   pre-commit install
-   ```
-
-Now you're ready to start developing!
+1. If you've added code that should be tested, add tests.
+1. Ensure your code passes all tests and linting.
+1. Update the documentation, if necessary.
+1. Issue the pull request!
 
 ## Coding Standards
 
@@ -72,13 +69,13 @@ Now you're ready to start developing!
 
 We strongly recommend setting up Ruff and Pyright in your text editor or IDE. This will help catch potential issues early in the development process.
 
-## Testing
+## CI/Testing
 
 - Write unit tests for all new code using pytest.
 - Aim for at least 80% test coverage for any new code.
-- Run the full test suite before submitting a pull request:
+- Run the full ci suite locally suite before submitting a pull request:
   ```
-  poetry run pytest
+  ./scripts/ci.sh
   ```
 - Tests should be written to work against both the latest Chainlit release and the main branch.
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ Welcome to the Chainlit Community repository! This project extends and enhances 
 [![Discord](https://dcbadge.vercel.app/api/server/ZThrUxbAYw?style=flat)](https://discord.gg/k73SQ3FyUh)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/chainlit_io.svg?style=social&label=Follow%20%40chainlit_io)](https://twitter.com/chainlit_io)
 
-## Getting started
-### Requirements
-* [uv](https://docs.astral.sh/uv/getting-started/installation/)
-
 ## 🌟 About This Project
 
 The Chainlit Community repository is a collaborative space for developers to contribute to the broader Chainlit ecosystem. While the [core Chainlit project](https://github.com/Chainlit/chainlit) focuses on essential features and integrations, this repository serves as a hub for community-maintained extensions, plugins, and integrations.
@@ -22,11 +18,11 @@ The Chainlit Community repository is a collaborative space for developers to con
 ### Roadmap
 
 1. Establish a clear contribution process and guidelines.
-2. Develop and maintain a curated list of community extensions and integrations.
-3. Implement a review and testing system for contributed code.
-4. Create centralized documentation for all sub-projects in the `docs` folder.
-5. Regularly synchronize with the core Chainlit project to ensure compatibility.
-6. Foster a vibrant community of contributors and users.
+1. Develop and maintain a curated list of community extensions and integrations.
+1. Implement a review and testing system for contributed code.
+1. Create centralized documentation for all sub-projects in the `docs` folder.
+1. Regularly synchronize with the core Chainlit project to ensure compatibility.
+1. Foster a vibrant community of contributors and users.
 
 ### Project Goals
 
@@ -49,9 +45,9 @@ The Chainlit Community repository is a collaborative space for developers to con
 We welcome contributions from developers of all skill levels. To get started:
 
 1. Fork this repository and create a new branch for your feature or fix.
-2. Develop your contribution, ensuring it follows our coding standards and guidelines.
-3. Write tests and documentation for your code.
-4. Submit a pull request with a clear description of your changes and their purpose.
+1. Develop your contribution, ensuring it follows our coding standards and guidelines.
+1. Write tests and documentation for your code.
+1. Submit a pull request with a clear description of your changes and their purpose.
 
 For detailed contribution guidelines, please refer to our [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
@@ -110,6 +106,6 @@ This shared repository structure fosters community collaboration, ensures qualit
 
 This project is licensed under the [Apache 2.0 License](LICENSE).
 
----
+______________________________________________________________________
 
 We're excited to see what the community will build with and for Chainlit. Thank you for being a part of this journey!

--- a/packages/data_layers/dynamodb/src/chainlit_dynamodb/data_layer.py
+++ b/packages/data_layers/dynamodb/src/chainlit_dynamodb/data_layer.py
@@ -30,7 +30,7 @@ from chainlit.user import PersistedUser, User
 
 if TYPE_CHECKING:
     from chainlit.element import Element
-    from types_boto3_dynamodb import DynamoDBClient
+    from mypy_boto3_dynamodb import DynamoDBClient
 
 
 _logger = logger.getChild("DynamoDB")

--- a/packages/data_layers/dynamodb/src/chainlit_dynamodb/data_layer.py
+++ b/packages/data_layers/dynamodb/src/chainlit_dynamodb/data_layer.py
@@ -30,7 +30,7 @@ from chainlit.user import PersistedUser, User
 
 if TYPE_CHECKING:
     from chainlit.element import Element
-    from mypy_boto3_dynamodb import DynamoDBClient
+    from types_boto3_dynamodb import DynamoDBClient
 
 
 _logger = logger.getChild("DynamoDB")

--- a/packages/data_layers/sqlalchemy/src/chainlit_sqlalchemy/data_layer.py
+++ b/packages/data_layers/sqlalchemy/src/chainlit_sqlalchemy/data_layer.py
@@ -272,6 +272,14 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def delete_thread(self, thread_id: str):
         if self.show_logger:
             logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
+
+        elements_query = """SELECT * FROM elements WHERE "threadId" = :id"""
+        elements = await self.execute_sql(elements_query, {"id": thread_id})
+
+        if self.storage_provider is not None and isinstance(elements, list):
+            for elem in filter(lambda x: x["objectKey"], elements):
+                await self.storage_provider.delete_file(object_key=elem["objectKey"])
+
         # Delete feedbacks/elements/steps/thread
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" IN (SELECT "id" FROM steps WHERE "threadId" = :id)"""
         elements_query = """DELETE FROM elements WHERE "threadId" = :id"""
@@ -441,7 +449,6 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         )
         if isinstance(element, list) and element:
             element_dict: Dict[str, Any] = element[0]
-
             return ElementDict(
                 id=element_dict["id"],
                 threadId=element_dict.get("threadId"),
@@ -450,6 +457,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 url=element_dict.get("url"),
                 objectKey=element_dict.get("objectKey"),
                 name=element_dict["name"],
+                props=json.loads(element_dict.get("props", "{}")),
                 display=element_dict["display"],
                 size=element_dict.get("size"),
                 language=element_dict.get("language"),
@@ -458,7 +466,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 playerConfig=element_dict.get("playerConfig"),
                 forId=element_dict.get("forId"),
                 mime=element_dict.get("mime"),
-            )  # pyright: ignore reportCallIssue
+            )
         else:
             return None
 
@@ -514,7 +522,10 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
         element_dict["url"] = uploaded_file.get("url")
         element_dict["objectKey"] = uploaded_file.get("object_key")
+
         element_dict_cleaned = {k: v for k, v in element_dict.items() if v is not None}
+        if "props" in element_dict_cleaned:
+            element_dict_cleaned["props"] = json.dumps(element_dict_cleaned["props"])
 
         columns = ", ".join(f'"{column}"' for column in element_dict_cleaned.keys())
         placeholders = ", ".join(f":{column}" for column in element_dict_cleaned.keys())
@@ -525,8 +536,21 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def delete_element(self, element_id: str, thread_id: str | None = None):
         if self.show_logger:
             logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
+
+        query = """SELECT * FROM elements WHERE "id" = :id"""
+        elements = await self.execute_sql(query, {"id": element_id})
+
+        if (
+            self.storage_provider is not None
+            and isinstance(elements, list)
+            and len(elements) > 0
+            and elements[0]["objectKey"]
+        ):
+            await self.storage_provider.delete_file(object_key=elements[0]["objectKey"])
+
         query = """DELETE FROM elements WHERE "id" = :id"""
         parameters = {"id": element_id}
+
         await self.execute_sql(query=query, parameters=parameters)
 
     async def get_all_user_threads(
@@ -588,7 +612,6 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 s."generation" AS step_generation,
                 s."showInput" AS step_showinput,
                 s."language" AS step_language,
-                s."indent" AS step_indent,
                 f."value" AS feedback_value,
                 f."comment" AS feedback_comment,
                 f."id" AS feedback_id
@@ -676,9 +699,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         generation=step_feedback.get("step_generation"),
                         showInput=step_feedback.get("step_showinput"),
                         language=step_feedback.get("step_language"),
-                        indent=step_feedback.get("step_indent"),
                         feedback=feedback,
-                    )  # pyright: ignore reportCallIssue
+                    )
                     # Append the step to the steps list of the corresponding ThreadDict
                     thread_dicts[thread_id]["steps"].append(step_dict)
 
@@ -700,9 +722,10 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         autoPlay=element.get("element_autoPlay"),
                         playerConfig=element.get("element_playerconfig"),
                         page=element.get("element_page"),
+                        props=json.loads(element.get("props", "{}")),
                         forId=element.get("element_forid"),
                         mime=element.get("element_mime"),
-                    )  # pyright: ignore reportCallIssue
+                    )
                     thread_dicts[thread_id]["elements"].append(element_dict)  # type: ignore
 
         return list(thread_dicts.values())

--- a/packages/storage_clients/azure/pyproject.toml
+++ b/packages/storage_clients/azure/pyproject.toml
@@ -15,6 +15,7 @@ pytest-chainlit = { workspace = true }
 dev = [
     "azure-identity>=1.14.1,<2",
     "pytest-chainlit",
+    "pytest-mock>=3.14.0",
 ]
 
 [build-system]

--- a/packages/storage_clients/azure/tests/test_azure.py
+++ b/packages/storage_clients/azure/tests/test_azure.py
@@ -3,5 +3,38 @@ from chainlit_azure import AzureStorageClient
 
 
 @pytest.fixture
-def storage_client():
-    return AzureStorageClient(account_url="fsdfds", container="34343")
+def storage_client(mocker):
+    # Mock the required clients
+    mock_data_lake_client = mocker.MagicMock()
+    mock_container_client = mocker.MagicMock()
+
+    # Create a mock AzureStorageClient
+    client = AzureStorageClient(
+        account_url="https://mockaccount.dfs.core.windows.net",
+        container="test-container",
+        credential="mock-credential",
+    )
+
+    # Mock the clients
+    client.data_lake_client = mock_data_lake_client
+    client.container_client = mock_container_client
+
+    # Mock the file client for upload
+    mock_file_client = mocker.MagicMock()
+    mock_container_client.get_file_client.return_value = mock_file_client
+
+    return client
+
+
+@pytest.mark.asyncio
+async def test_delete_file(storage_client, mocker):
+    # Mock the file client for delete
+    mock_file_client = mocker.MagicMock()
+    storage_client.container_client.get_file_client.return_value = mock_file_client
+
+    # Test delete
+    result = await storage_client.delete_file("test_delete.txt")
+    assert result is True
+
+    # Verify the delete was called
+    mock_file_client.delete_file.assert_called_once()

--- a/packages/storage_clients/s3/tests/test_s3.py
+++ b/packages/storage_clients/s3/tests/test_s3.py
@@ -44,3 +44,191 @@ async def test_upload_file(s3_mock):
     # Verify that the file exists in the mock S3
     response = s3_mock.get_object(Bucket="my-test-bucket", Key="test.txt")
     assert response["Body"].read().decode() == "This is a test file"
+
+
+@pytest.mark.asyncio
+async def test_delete_file(s3_mock):
+    # Initialize the S3StorageClient with the mock bucket
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Upload a test file first
+    await client.upload_file(
+        object_key="test_delete.txt", data="File to delete", mime="text/plain"
+    )
+
+    # Delete the file
+    result = await client.delete_file("test_delete.txt")
+    assert result is True
+
+    # Verify the file no longer exists
+    with pytest.raises(s3_mock.exceptions.NoSuchKey):
+        s3_mock.get_object(Bucket="my-test-bucket", Key="test_delete.txt")
+
+
+@pytest.mark.asyncio
+async def test_get_read_url(s3_mock):
+    # Initialize the S3StorageClient with the mock bucket
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Upload a test file first
+    await client.upload_file(
+        object_key="test_read.txt", data="File to read", mime="text/plain"
+    )
+
+    # Get the presigned URL
+    url = await client.get_read_url("test_read.txt")
+
+    # Verify the URL contains expected components
+    assert "https://" in url
+    assert "my-test-bucket" in url
+    assert "test_read.txt" in url
+    assert "AWSAccessKeyId" in url
+    assert "Signature" in url
+    assert "Expires" in url
+
+
+@pytest.mark.asyncio
+async def test_upload_file_error():
+    # Initialize client with invalid credentials to force error
+    client = S3StorageClient(bucket="invalid-bucket", aws_access_key_id="invalid")
+
+    # Attempt upload which should fail
+    result = await client.upload_file(object_key="test.txt", data="This is a test file")
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_delete_file_error():
+    # Initialize client with invalid credentials to force error
+    client = S3StorageClient(bucket="invalid-bucket", aws_access_key_id="invalid")
+
+    # Attempt delete which should fail
+    result = await client.delete_file("nonexistent.txt")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_get_read_url_error():
+    # Initialize client with invalid credentials to force error
+    client = S3StorageClient(bucket="invalid-bucket", aws_access_key_id="invalid")
+
+    # Attempt to get URL which should return the key
+    result = await client.get_read_url("test.txt")
+    assert result == "test.txt"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_bytes(s3_mock):
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Test with bytes data
+    bytes_data = b"Binary content"
+    result = await client.upload_file(
+        object_key="binary.dat", data=bytes_data, mime="application/octet-stream"
+    )
+
+    # Verify upload succeeded
+    assert result["object_key"] == "binary.dat"
+    response = s3_mock.get_object(Bucket="my-test-bucket", Key="binary.dat")
+    assert response["Body"].read() == bytes_data
+    assert response["ContentType"] == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_different_mimes(s3_mock):
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Test JSON content type
+    await client.upload_file(
+        object_key="data.json", data='{"key": "value"}', mime="application/json"
+    )
+
+    response = s3_mock.get_object(Bucket="my-test-bucket", Key="data.json")
+    assert response["ContentType"] == "application/json"
+
+    # Test HTML content type
+    await client.upload_file(
+        object_key="page.html", data="<html></html>", mime="text/html"
+    )
+
+    response = s3_mock.get_object(Bucket="my-test-bucket", Key="page.html")
+    assert response["ContentType"] == "text/html"
+
+
+def test_sync_methods(s3_mock):
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Test sync upload
+    result = client.sync_upload_file(
+        object_key="sync_test.txt", data="Sync upload test", mime="text/plain"
+    )
+    assert result["object_key"] == "sync_test.txt"
+
+    # Test sync get_read_url
+    url = client.sync_get_read_url("sync_test.txt")
+    assert "https://" in url
+    assert "sync_test.txt" in url
+
+    # Test sync delete
+    assert client.sync_delete_file("sync_test.txt") is True
+
+
+@pytest.mark.asyncio
+async def test_upload_file_overwrite(s3_mock):
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Upload initial file
+    await client.upload_file(
+        object_key="overwrite.txt", data="Original content", mime="text/plain"
+    )
+
+    # Upload with same key but different content
+    await client.upload_file(
+        object_key="overwrite.txt", data="New content", mime="text/plain"
+    )
+
+    # Verify content was overwritten
+    response = s3_mock.get_object(Bucket="my-test-bucket", Key="overwrite.txt")
+    assert response["Body"].read().decode() == "New content"
+
+
+@pytest.mark.asyncio
+async def test_unicode_handling(s3_mock):
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Test with Unicode content and filename
+    unicode_content = "Hello 世界 🌍"
+    unicode_filename = "hello_世界_🌍.txt"
+
+    await client.upload_file(
+        object_key=unicode_filename,
+        data=unicode_content,
+        mime="text/plain; charset=utf-8",
+    )
+
+    # Verify content was stored correctly
+    response = s3_mock.get_object(Bucket="my-test-bucket", Key=unicode_filename)
+    assert response["Body"].read().decode() == unicode_content
+
+
+@pytest.mark.asyncio
+async def test_url_expiry(s3_mock):
+    client = S3StorageClient(bucket="my-test-bucket")
+
+    # Upload a test file
+    await client.upload_file(
+        object_key="expiry_test.txt", data="Test content", mime="text/plain"
+    )
+
+    # Get URL and verify expiry parameter
+    url = await client.get_read_url("expiry_test.txt")
+    assert "Expires=" in url
+
+    # Verify expiry is roughly correct (within 5 seconds)
+    import time
+
+    from chainlit.data.storage_clients.base import EXPIRY_TIME
+
+    expires_at = int(url.split("Expires=")[1].split("&")[0])
+    expected_expiry = int(time.time()) + EXPIRY_TIME
+    assert abs(expires_at - expected_expiry) < 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest>=8.3.4",
     "ruff>=0.8.3",
+    "pre-commit>=4.1.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+### ci convenience shell script.
+### Usage: ./ci.sh [command]
+### If no command is provided, the script will run the following commands:
+### ruff format --check
+### ruff check
+### pytest
+### pyright
+### Otherwise, the script will run `uv run --all-packages $command`.
+
+UV="uv run --all-packages"
+
+if [ -n "$1" ]; then
+  $UV $1
+  exit 0
+fi
+
+set -ex
+$UV ruff format --check
+$UV ruff check
+$UV pytest
+$UV pyright

--- a/uv.lock
+++ b/uv.lock
@@ -390,6 +390,7 @@ dependencies = [
 dev = [
     { name = "azure-identity" },
     { name = "pytest-chainlit" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -399,6 +400,7 @@ requires-dist = [{ name = "azure-storage-file-datalake", specifier = ">=12.14.0,
 dev = [
     { name = "azure-identity", specifier = ">=1.14.1,<2" },
     { name = "pytest-chainlit", editable = "packages/pytest" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
 
 [[package]]
@@ -1630,6 +1632,18 @@ wheels = [
 name = "pytest-chainlit"
 version = "0.1.0"
 source = { editable = "packages/pytest" }
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
+]
 
 [[package]]
 name = "python-dateutil"

--- a/uv.lock
+++ b/uv.lock
@@ -350,6 +350,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
+
+[[package]]
 name = "chainlit"
 version = "2.0.4"
 source = { git = "https://github.com/Chainlit/chainlit.git?subdirectory=backend%2F#396a5bd7774e5e4f9d2712507b41380a6e250f36" }
@@ -413,6 +422,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -424,6 +434,7 @@ requires-dist = [{ name = "chainlit", git = "https://github.com/Chainlit/chainli
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
@@ -688,6 +699,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +728,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/72/d83b98cd106541e8f5e5bfab8ef2974ab45a62e8a6c5b5e6940f26d2ed4b/fastapi-0.115.6.tar.gz", hash = "sha256:9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654", size = 301336 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/b3/7e4df40e585df024fac2f80d1a2d579c854ac37109675db2b0cc22c0bb9e/fastapi-0.115.6-py3-none-any.whl", hash = "sha256:e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305", size = 94843 },
+]
+
+[[package]]
+name = "filelock"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/9c/0b15fb47b464e1b663b1acd1253a062aa5feecb07d4e597daea542ebd2b5/filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e", size = 18027 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338", size = 16164 },
 ]
 
 [[package]]
@@ -930,6 +959,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/bf/c68c46601bacd4c6fb4dd751a42b6e7087240eaabc6487f2ef7a48e0e8fc/identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251", size = 99217 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/a1/68a395c17eeefb04917034bd0a1bfa765e7654fa150cca473d669aa3afb5/identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881", size = 99083 },
 ]
 
 [[package]]
@@ -1367,6 +1405,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1385,6 +1432,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf", size = 18423 },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/13/b62d075317d8686071eb843f0bb1f195eb332f48869d3c31a4c6f1e063ac/pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4", size = 193330 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/b3/df14c580d82b9627d173ceea305ba898dca135feb360b6d84019d0803d3b/pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b", size = 220560 },
 ]
 
 [[package]]
@@ -2036,6 +2099,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/54/0eb4441bf38c70f6ed1886dddb2e29d1650026041d19e49fc373e332fa60/uvicorn-0.25.0.tar.gz", hash = "sha256:6dddbad1d7ee0f5140aba5ec138ddc9612c5109399903828b4874c9937f009c2", size = 40724 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/59/fddd9df489fe27f492cc97626e03663fb3b9b6ef7ce8597a7cdc5f2cbbad/uvicorn-0.25.0-py3-none-any.whl", hash = "sha256:ce107f5d9bd02b4636001a77a4e74aab5e1e2b146868ebbad565237145af444c", size = 60303 },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ca/f23dcb02e161a9bba141b1c08aa50e8da6ea25e6d780528f1d385a3efe25/virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35", size = 7658028 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779", size = 4282379 },
 ]
 
 [[package]]


### PR DESCRIPTION
Various fixups and improvements:

* Bump SQLAlchemy data layer and DynamoDB storage clients from `chainlit:main`, closes #8.
* Additional tests and fixups for S3, Azure and DynamoDB storage clients, closes #10.
* Pre-commit hooks, closes #20.
* Revised getting started instructions.